### PR TITLE
Add design plan for sports tracking app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Yavuz
+
+Bu depo, Maçkolik tarzında bir spor takip uygulamasının ürün ve teknik tasarımını içerir. Ayrıntılı planlamaya `docs/mackolik_app_design.md` dosyasından ulaşabilirsiniz.

--- a/docs/mackolik_app_design.md
+++ b/docs/mackolik_app_design.md
@@ -1,0 +1,111 @@
+# Maçkolik Tarzı Uygulama Tasarımı
+
+## 1. Ürün Özeti
+Maçkolik tarzında tasarlanan bu uygulama, futbol başta olmak üzere popüler takım sporlarının canlı skorlarını, maç istatistiklerini, haberlerini ve topluluk etkileşimini tek bir platformda bir araya getirir. Kullanıcılar favori takımlarını ve liglerini belirleyerek kişiselleştirilmiş bir deneyim yaşarken, uygulama gerçek zamanlı veri akışıyla güncel kalmalarını sağlar.
+
+## 2. Kullanıcı Profilleri
+- **Misafir kullanıcı**: Hesap oluşturmadan lig ve maç araması yapabilir, canlı skorları takip edebilir.
+- **Kayıtlı kullanıcı**: Favori takım/lig seçimleri, bildirim yönetimi, kişiselleştirilmiş haber akışı.
+- **Premium kullanıcı**: Reklamsız deneyim, detaylı analizler, geçmiş maç veri arşivi, özel röportajlar.
+
+## 3. Temel Özellikler
+### 3.1 Canlı Skor ve Maç Takibi
+- Gerçek zamanlı skor güncellemeleri.
+- Maç istatistikleri (topla oynama, şut, faul, kart vb.).
+- Maç öncesi kadrolar, sakatlık listesi, hakem bilgisi.
+- Canlı anlatım ve önemli anlar (gol, kırmızı kart, penaltı vb.).
+
+### 3.2 Haber ve İçerik Akışı
+- Takım ve lig bazlı filtrelenebilir haber listesi.
+- Video özetleri, röportajlar, podcast entegrasyonu.
+- Editör seçkisi ve kullanıcıya özel öneriler.
+
+### 3.3 Bildirim ve Alarm Sistemi
+- Maç başlama, gol, kart, devre arası/maç sonu bildirimleri.
+- Transfer söylentileri, sakatlık raporları gibi önemli haberler için push bildirimleri.
+- Takvim entegrasyonu ile maç hatırlatıcıları.
+
+### 3.4 Topluluk ve Etkileşim
+- Maç öncesi/sonrası yorum alanı, anketler.
+- Kullanıcıların maç tahminleri ve puan tablosu.
+- Arkadaş ekleme, grup sohbetleri, liderlik tabloları.
+
+### 3.5 İstatistik ve Analiz Merkezi
+- Lig ve takım sıralamaları, form grafikleri.
+- Oyuncu profilleri, sezon bazlı performans karşılaştırmaları.
+- Isı haritaları, pas bağlantı grafikleri gibi gelişmiş görselleştirmeler.
+
+## 4. Bilgi Mimarisi
+1. **Ana Sekmeler**
+   - Anasayfa (kişiselleştirilmiş içerik)
+   - Canlı (anlık devam eden maçlar)
+   - Haberler
+   - Topluluk
+   - Profil
+2. **Alt Navigasyon**
+   - Arama
+   - Favoriler
+   - Takvim
+
+## 5. Ekran Akışları
+1. **Onboarding**
+   - Dil seçimi, spor ve lig tercihi
+   - Bildirim izinleri
+2. **Ana Sayfa**
+   - Favori takımlardan öne çıkan maçlar ve haberler
+3. **Maç Detay Ekranı**
+   - Canlı skor, istatistikler, yorumlar sekmeli yapı
+4. **Haber Detayı**
+   - Haber metni, multimedya, ilgili içerikler
+5. **Topluluk**
+   - Maç özel forumlar, genel spor tartışma odaları
+
+## 6. Teknik Mimarî Taslağı
+- **Mobil platform**: Flutter veya React Native ile çapraz platform geliştirme.
+- **Backend**: Node.js (NestJS) veya Python (FastAPI) tabanlı mikro servis mimarisi.
+- **Veritabanı**: Canlı skor için gerçek zamanlı veri sağlayıcı entegrasyonu + PostgreSQL (kalıcı veriler) + Redis (cache).
+- **Gerçek zamanlı iletişim**: WebSocket/SSE ile canlı skor ve bildirim güncellemeleri.
+- **Analitik**: Google Analytics/Firebase + özel raporlar için BigQuery/Redshift.
+- **CI/CD**: GitHub Actions veya GitLab CI, TestFlight/Google Play Internal Testing.
+
+## 7. Veri Kaynakları ve Entegrasyonlar
+- Spor veri sağlayıcıları (Opta, Sportradar, RapidAPI vb.)
+- Sosyal medya API’leri (Twitter/X, Instagram) ile takım haberleri.
+- Reklam ve monetizasyon (Google Ad Manager, in-app purchase).
+
+## 8. Gelir Modeli
+- Reklam geliri (banner, video, sponsor içerikleri).
+- Premium abonelik (reklamsız, gelişmiş istatistikler, özel içerik).
+- Ortaklık anlaşmaları (spor kulüpleri, bahis şirketleri, medya partnerleri).
+
+## 9. Yol Haritası (12 Ay)
+1. **Ay 1-2**: Gereksinim toplama, tasarım sisteminin oluşturulması.
+2. **Ay 3-4**: MVP geliştirme (canlı skor, favori takımlar, temel haber akışı).
+3. **Ay 5-6**: Topluluk özellikleri, bildirim sistemi.
+4. **Ay 7-9**: Gelişmiş istatistikler, veri görselleştirmeleri, premium paket.
+5. **Ay 10-12**: Performans optimizasyonu, A/B testleri, pazarlama lansmanı.
+
+## 10. Görsel Tasarım İlkeleri
+- Karanlık ve açık tema desteği.
+- Takım renkleri ile uyumlu vurgu renkleri.
+- İçerik yoğun ekranlarda tipografi hiyerarşisini güçlendiren layout.
+- Canlı skor ekranında kontrast ve okunabilirliği yüksek bileşenler.
+
+## 11. Başarı Metrikleri
+- Günlük aktif kullanıcı (DAU) ve oturum süresi.
+- Bildirim açılma ve tıklanma oranları.
+- Premium dönüşüm oranı.
+- Kullanıcı memnuniyeti (NPS), App Store/Google Play puanları.
+
+## 12. Riskler ve Önlemler
+- **Veri lisansı**: Sağlayıcılarla sözleşmelerin zamanında yapılması.
+- **Sunucu yükü**: Trafik artışına karşı otomatik ölçeklenebilir altyapı.
+- **Rekabet**: Kullanıcı geri bildirimlerinin hızlı değerlendirilmesi, benzersiz topluluk özellikleri.
+
+## 13. Gelecek Geliştirmeler
+- E-spor ligleri ve diğer spor dallarının eklenmesi.
+- Yapay zekâ destekli maç tahminleri ve bahis analizi.
+- Akıllı TV ve giyilebilir cihaz uygulamaları.
+
+## 14. Sonuç
+Bu tasarım dokümanı, Maçkolik benzeri bir uygulamanın kullanıcı ihtiyaçlarını, teknik gereksinimlerini ve büyüme stratejisini ana hatlarıyla belirler. Modüler mimarisi ve kişiselleştirme odaklı yaklaşımıyla uygulama, sporseverlerin günlük başvuru noktası olmayı hedefler.


### PR DESCRIPTION
## Summary
- add detailed product and technical design document for a Maçkolik-style sports tracking application
- refresh README to point to the new design documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8084ba2108325b60817208f44e77d